### PR TITLE
Update p02_printing_to_file.rst

### DIFF
--- a/source/c05/p02_printing_to_file.rst
+++ b/source/c05/p02_printing_to_file.rst
@@ -16,7 +16,7 @@
 
 .. code-block:: python
 
-    with open('somefile.txt', 'rt') as f:
+    with open('somefile.txt', 'wt') as f:
         print('Hello World!', file=f)
 
 ----------


### PR DESCRIPTION
虽然原书写的打开方式也是 rt， 然而输出到文件明显应该是 wt, 使用rt会出现异常如下。

```
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
io.UnsupportedOperation: not writable
```