### PR TITLE
更改示例中的对象名`a`为文中写道的`s`

### DIFF
--- a/source/c01/p11_naming_slice.rst
+++ b/source/c01/p11_naming_slice.rst
@@ -60,12 +60,12 @@
 
 .. code-block:: python
 
-    >>> a = slice(5, 50, 2)
-    >>> a.start
+    >>> s = slice(5, 50, 2)
+    >>> s.start
     5
-    >>> a.stop
+    >>> s.stop
     50
-    >>> a.step
+    >>> s.step
     2
     >>>
 


### PR DESCRIPTION
文中写到：`如果你有一个切片对象s，你可以分别调用它的s.start, s.stop, s.step属性来获取更多的信息。`。但示例中的对象名称为`a`。