### PR TITLE
修改代码错误

### DIFF
--- a/source/c04/p01_manually_consuming_iterator.rst
+++ b/source/c04/p01_manually_consuming_iterator.rst
@@ -32,7 +32,7 @@
 
     with open('/etc/passwd') as f:
         while True:
-            line = next(f)
+            line = next(f, None)
             if line is None:
                 break
             print(line, end='')


### PR DESCRIPTION
next(iterator[, default])如果没有设置默认值，迭代结束的时候仍然会抛出StopIteration异常