### PR TITLE
Update p07_specify_regexp_for_shortest_match.rst

### DIFF
--- a/source/c02/p07_specify_regexp_for_shortest_match.rst
+++ b/source/c02/p07_specify_regexp_for_shortest_match.rst
@@ -16,7 +16,7 @@
 
 .. code-block:: python
 
-    >>> str_pat = re.compile(r'\"(.*)\"')
+    >>> str_pat = re.compile(r'"(.*)"')
     >>> text1 = 'Computer says "no."'
     >>> str_pat.findall(text1)
     ['no.']
@@ -33,7 +33,7 @@
 
 .. code-block:: python
 
-    >>> str_pat = re.compile(r'\"(.*?)\"')
+    >>> str_pat = re.compile(r'"(.*?)"')
     >>> str_pat.findall(text2)
     ['no.', 'yes.']
     >>>


### PR DESCRIPTION
row 19: str_pat = re.compile(r'\\"(.*)\\"')  should be str_pat = re.compile(r'"(.*)"')
row 36: str_pat = re.compile(r'\\"(.*?)\\"') should be str_pat = re.compile(r'"(.*?)"')

"\\" just don't works.