### PR TITLE
根据上下文，__init__中属性名称是 self._first_name 而不是 self.first_name

### DIFF
--- a/source/c08/p06_create_managed_attributes.rst
+++ b/source/c08/p06_create_managed_attributes.rst
@@ -17,7 +17,7 @@
 
     class Person:
         def __init__(self, first_name):
-            self.first_name = first_name
+            self._first_name = first_name
 
         # Getter function
         @property


### PR DESCRIPTION
def __init__(self, first_name):
            self._first_name = first_name