### PR TITLE
dropwhile() 示例代码错误

### DIFF
--- a/source/c04/p08_skip_first_part_of_iterable.rst
+++ b/source/c04/p08_skip_first_part_of_iterable.rst
@@ -41,7 +41,7 @@
 
     >>> from itertools import dropwhile
     >>> with open('/etc/passwd') as f:
-    ...     for line in dropwhile(lambda line: not line.startswith('#'), f):
+    ...     for line in dropwhile(lambda line: line.startswith('#'), f):
     ...         print(line, end='')
     ...
     nobody:*:-2:-2:Unprivileged User:/var/empty:/usr/bin/false


### PR DESCRIPTION
第一次示例 LIne 44，应该是：
    ...     for line in dropwhile(lambda line: line.startswith('#'), f):
而不是：
    ...     for line in dropwhile(lambda line: not line.startswith('#'), f):
因为这里的目的是不显示 # 开头的文本