### PR TITLE
docs: fix simple typo, undifined -> undefined

### DIFF
--- a/cookbook/c03/p07_inf_nan.py
+++ b/cookbook/c03/p07_inf_nan.py
@@ -16,7 +16,7 @@ def inf_nan():
     print(a * 10 == a)
     print(10 / a)
 
-    # undifined
+    # undefined
     print(a / a)
     print(a + b)
 


### PR DESCRIPTION
There is a small typo in cookbook/c03/p07_inf_nan.py.

Should read `undefined` rather than `undifined`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md