### PR TITLE
Update p02_write_simple_c_extension_module.rst

### DIFF
--- a/source/c15/p02_write_simple_c_extension_module.rst
+++ b/source/c15/p02_write_simple_c_extension_module.rst
@@ -34,7 +34,7 @@
 有了这些，下面我们演示下编写扩展函数的一个简单例子：
 
 ::
-
+    /* pysample.c */
     #include "Python.h"
     #include "sample.h"
 
@@ -103,20 +103,16 @@
     # setup.py
     from distutils.core import setup, Extension
 
-    setup(name='sample',
+    setup(name="sample", 
           ext_modules=[
-            Extension('sample',
-                      ['pysample.c'],
-                      include_dirs = ['/some/dir'],
-                      define_macros = [('FOO','1')],
-                      undef_macros = ['BAR'],
-                      library_dirs = ['/usr/local/lib'],
-                      libraries = ['sample']
+            Extension("sample",
+                      ["../sample.c", "pysample.c"],
+                      include_dirs = ['..'],
                       )
             ]
     )
 
-为了构建最终的函数库，只需简单的使用 ``python3 buildlib.py build_ext --inplace`` 命令即可：
+为了构建最终的函数库，只需简单的使用 ``python3 setup.py build_ext --inplace`` 命令即可：
 
 ::
 


### PR DESCRIPTION
在``15.2 简单的C扩展模块``中，按照译文代码不能正常构建扩展模块。由于没有原文书籍参考是否是译文问题，但在作者源码示例仓库 [python-cookbook](https://github.com/dabeaz/python-cookbook) 中，代码与目前译文是存在出入的。因此修改了 15.2 的部分代码块。可能与原书籍代码存在出入，但修改后的代码可以正常构建扩展模块。