### PR TITLE
fix: 代码违背文字描述

### DIFF
--- a/source/c08/p06_create_managed_attributes.rst
+++ b/source/c08/p06_create_managed_attributes.rst
@@ -17,7 +17,7 @@
 
     class Person:
         def __init__(self, first_name):
-            self._first_name = first_name
+            self.first_name = first_name
 
         # Getter function
         @property


### PR DESCRIPTION
文字描述：“另外，你可能还会问为什么 ``__init__()`` 方法中设置了 ``self.first_name`` 而不是 ``self._first_name`` 。”

参考：
https://github.com/yidao620c/python3-cookbook/blob/master/cookbook/c08/p06_managed_attribute.py#L12