### PR TITLE
Update p17_handle_html_xml_in_text.rst

### DIFF
--- a/source/c02/p17_handle_html_xml_in_text.rst
+++ b/source/c02/p17_handle_html_xml_in_text.rst
@@ -49,7 +49,7 @@
     >>> s = 'Spicy &quot;Jalape&#241;o&quot.'
     >>> from html.parser import HTMLParser
     >>> p = HTMLParser()
-    >>> p.unescape(s)
+    >>> p.unescape(s)  # Python3.5以后使用 html.unescape(s)
     'Spicy "Jalapeño".'
     >>>
     >>> t = 'The prompt is &gt;&gt;&gt;'


### PR DESCRIPTION
Python3.5以后使用 html.unescape(s)